### PR TITLE
NaCL compatible seeding

### DIFF
--- a/src/main/java/com/ltonetwork/seasalt/sign/Ed25519.java
+++ b/src/main/java/com/ltonetwork/seasalt/sign/Ed25519.java
@@ -57,11 +57,7 @@ public class Ed25519 implements Signer {
 
     private byte[] generatePrivateKey(byte[] seed) {
         try {
-            Hasher sha256 = new Hasher("SHA-256");
-            Hasher blake2b256 = new Hasher("Blake2b-256");
-            byte[] hashed_seed = blake2b256.hash(seed).getBytes();
-            byte[] hashed_seed_2 = sha256.hash(hashed_seed).getBytes();
-            return sha256.hash(hashed_seed_2).getBytes();
+            return new Hasher("SHA-256").hash(seed).getBytes();
         } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
             throw new RuntimeException("Could not find SHA-256 and/or Blake2b-256 hashing algorithms");
         }

--- a/src/main/java/com/ltonetwork/seasalt/sign/Ed25519.java
+++ b/src/main/java/com/ltonetwork/seasalt/sign/Ed25519.java
@@ -2,38 +2,40 @@ package com.ltonetwork.seasalt.sign;
 
 import com.ltonetwork.seasalt.Binary;
 import com.ltonetwork.seasalt.KeyPair;
-import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
-import org.bouncycastle.crypto.generators.Ed25519KeyPairGenerator;
-import org.bouncycastle.crypto.params.Ed25519KeyGenerationParameters;
+import com.ltonetwork.seasalt.hash.Hasher;
 import org.bouncycastle.crypto.params.Ed25519PrivateKeyParameters;
 import org.bouncycastle.crypto.params.Ed25519PublicKeyParameters;
 import org.bouncycastle.crypto.signers.Ed25519Signer;
 
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.SecureRandom;
 
 public class Ed25519 implements Signer {
     public KeyPair keyPair() {
         SecureRandom srSeed = new SecureRandom();
-        byte[] privateKey = generatePrivateKey(srSeed);
-        byte[] publicKey = privateToPublic(privateKey);
-        return new KeyPair(publicKey, privateKey);
+        return keyPairFromSeed(srSeed.generateSeed(64));
     }
 
     public KeyPair keyPairFromSeed(byte[] seed) {
-        SecureRandom srSeed = new SecureRandom(seed);
-        byte[] privateKey = generatePrivateKey(srSeed);
+        byte[] privateKey = generatePrivateKey(seed);
         byte[] publicKey = privateToPublic(privateKey);
-        return new KeyPair(publicKey, privateKey);
+        byte[] concatenatedPrivateKey = new byte[64];
+        System.arraycopy(privateKey, 0, concatenatedPrivateKey, 0, 32);
+        System.arraycopy(publicKey, 0, concatenatedPrivateKey, 32, 32);
+        return new KeyPair(publicKey, concatenatedPrivateKey);
     }
 
     public KeyPair keyPairFromSecretKey(byte[] privateKey) {
-        byte[] publicKey = privateToPublic(privateKey);
+        byte[] actualPrivateKey = concatenatedPrivateToSeed(privateKey);
+        byte[] publicKey = privateToPublic(actualPrivateKey);
         return new KeyPair(publicKey, privateKey);
     }
 
     public Signature signDetached(byte[] msg, byte[] privateKey) {
+        byte[] actualPrivateKey = concatenatedPrivateToSeed(privateKey);
         Ed25519Signer signer = new Ed25519Signer();
-        Ed25519PrivateKeyParameters privateKeyParameters = new Ed25519PrivateKeyParameters(privateKey);
+        Ed25519PrivateKeyParameters privateKeyParameters = new Ed25519PrivateKeyParameters(actualPrivateKey);
         signer.init(true, privateKeyParameters);
         signer.update(msg, 0, msg.length);
         return new Signature(signer.generateSignature());
@@ -48,16 +50,28 @@ public class Ed25519 implements Signer {
     }
 
     private byte[] privateToPublic(byte[] privateKey) {
-        Ed25519PrivateKeyParameters sk = new Ed25519PrivateKeyParameters(privateKey);
+        byte[] actualPrivateKey = concatenatedPrivateToSeed(privateKey);
+        Ed25519PrivateKeyParameters sk = new Ed25519PrivateKeyParameters(actualPrivateKey);
         return sk.generatePublicKey().getEncoded();
     }
 
-    private byte[] generatePrivateKey(SecureRandom seed) {
-        Ed25519KeyPairGenerator generator = new Ed25519KeyPairGenerator();
-        Ed25519KeyGenerationParameters keygenParams = new Ed25519KeyGenerationParameters(seed);
-        generator.init(keygenParams);
-        AsymmetricCipherKeyPair keypair = generator.generateKeyPair();
-        Ed25519PrivateKeyParameters privParams = (Ed25519PrivateKeyParameters) keypair.getPrivate();
-        return privParams.getEncoded();
+    private byte[] generatePrivateKey(byte[] seed) {
+        try {
+            Hasher sha256 = new Hasher("SHA-256");
+            Hasher blake2b256 = new Hasher("Blake2b-256");
+            byte[] hashed_seed = blake2b256.hash(seed).getBytes();
+            byte[] hashed_seed_2 = sha256.hash(hashed_seed).getBytes();
+            return sha256.hash(hashed_seed_2).getBytes();
+        } catch (NoSuchAlgorithmException | NoSuchProviderException e) {
+            throw new RuntimeException("Could not find SHA-256 and/or Blake2b-256 hashing algorithms");
+        }
+    }
+
+    private byte[] concatenatedPrivateToSeed(byte[] privateKey) {
+        if(!(privateKey.length == 32 || privateKey.length == 64))
+            throw new IllegalArgumentException("Private key length should be either 32 or 64 bytes long");
+        byte[] actualPrivateKey = new byte[32];
+        System.arraycopy(privateKey, 0, actualPrivateKey, 0, 32);
+        return actualPrivateKey;
     }
 }

--- a/src/test/java/sign/Ed25519Test.java
+++ b/src/test/java/sign/Ed25519Test.java
@@ -44,11 +44,9 @@ public class Ed25519Test {
 
     @Test
     public void testKeyPairFromSeedAndNonce() {
-        byte[] seed = new byte[]{-42, 20, -66, -118, -75, 113, 95, -8, -85, 70, 50, 81, -76, -75, -59, 113, -18, 101, 110, 98, 67, -74, -6, 66, 6, -40, 22, -18, -111, 121, -23, -61};
-        int nonce = 1;
-        byte[] actual_seed = Bytes.concat(Ints.toByteArray(nonce), seed);
+        byte[] seed = new byte[]{-72, -39, -90, -96, 104, -56, -55, -33, -112, 4, -57, 50, -99, 55, -72, -116, 102, -113, -39, -88, -48, -103, -34, -60, 76, -51, -78, 92, 32, -53, -46, 115};
 
-        KeyPair myKeyPair = ed25519.keyPairFromSeed(actual_seed);
+        KeyPair myKeyPair = ed25519.keyPairFromSeed(seed);
 
         Assertions.assertArrayEquals(
                 myKeyPair.getPrivateKey().getBytes(),

--- a/src/test/java/sign/Ed25519Test.java
+++ b/src/test/java/sign/Ed25519Test.java
@@ -1,7 +1,10 @@
 package sign;
 
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.Ints;
 import com.ltonetwork.seasalt.Binary;
 import com.ltonetwork.seasalt.KeyPair;
+import com.ltonetwork.seasalt.hash.Hasher;
 import com.ltonetwork.seasalt.sign.Ed25519;
 import com.ltonetwork.seasalt.sign.Signature;
 import org.junit.jupiter.api.Assertions;
@@ -9,6 +12,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.util.Arrays;
 import java.util.Random;
 
 public class Ed25519Test {
@@ -38,6 +44,22 @@ public class Ed25519Test {
 
         Assertions.assertNotNull(myKeyPair.getPrivateKey());
         Assertions.assertNotNull(myKeyPair.getPublicKey());
+    }
+
+    @Test
+    public void testKeyPairFromSeedAndNonce() {
+        byte[] seed = new byte[]{-42, 20, -66, -118, -75, 113, 95, -8, -85, 70, 50, 81, -76, -75, -59, 113, -18, 101, 110, 98, 67, -74, -6, 66, 6, -40, 22, -18, -111, 121, -23, -61};
+        int nonce = 1;
+        byte[] actual_seed = Bytes.concat(Ints.toByteArray(nonce), seed);
+
+        KeyPair myKeyPair = ed25519.keyPairFromSeed(actual_seed);
+
+        Assertions.assertArrayEquals(
+                myKeyPair.getPrivateKey().getBytes(),
+                new byte[]{83, -69, -105, 5, 58, 122, -47, -83, 63, 15, -105, -56, -117, 48, 88, 79, 96, -102, 119, 47, -42, -40, 43, 110, -124, -38, 105, 12, -2, -54, -55, -94, -64, -54, 94, -105, 47, 81, 79, 39, 31, -38, -89, 12, -104, -96, -40, 86, 9, -76, 100, -56, 86, 33, 29, -105, -112, 29, 102, -4, 77, 120, 57, -47});
+        Assertions.assertArrayEquals(
+                myKeyPair.getPublicKey().getBytes(),
+                new byte[]{-64, -54, 94, -105, 47, 81, 79, 39, 31, -38, -89, 12, -104, -96, -40, 86, 9, -76, 100, -56, 86, 33, 29, -105, -112, 29, 102, -4, 77, 120, 57, -47});
     }
 
     @Test

--- a/src/test/java/sign/Ed25519Test.java
+++ b/src/test/java/sign/Ed25519Test.java
@@ -4,7 +4,6 @@ import com.google.common.primitives.Bytes;
 import com.google.common.primitives.Ints;
 import com.ltonetwork.seasalt.Binary;
 import com.ltonetwork.seasalt.KeyPair;
-import com.ltonetwork.seasalt.hash.Hasher;
 import com.ltonetwork.seasalt.sign.Ed25519;
 import com.ltonetwork.seasalt.sign.Signature;
 import org.junit.jupiter.api.Assertions;
@@ -12,9 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.util.Arrays;
 import java.util.Random;
 
 public class Ed25519Test {


### PR DESCRIPTION
The problem: private key from seed in NaCL didn't correspond to the same private key in SeaSalt

The solution: BouncyCastle (the library used in SeaSalt) uses Java's SecureRandom which always provides different seed . There are some workarounds - https://stackoverflow.com/questions/27341294/get-deterministic-values-from-securerandom, but it's irrelevant to continue using SecureRandom. Instead of doing that, I moved to the NaCL's approach of doing SHA-256 over the given seed and providing this as private key parameter. Deriving the public key from it stays the same, however, I changed the private key to be 64-bytes long (same as in NaCL) which consists of the seed + public key.